### PR TITLE
Fix route context type

### DIFF
--- a/src/app/api/users/[id]/flags/route.ts
+++ b/src/app/api/users/[id]/flags/route.ts
@@ -4,12 +4,11 @@ import pool from '@/lib/db';
 export const runtime = 'nodejs';
 
 type Params = { id: string };
-type Ctx = { params: Params };
 
 /* GET /api/users/[id]/flags */
 export async function GET(
   _req: Request,
-  { params }: Ctx,            // ← убрали Promise, сразу деструктурируем
+  { params }: { params: Params }, // inline context type
 ) {
   try {
     const client = await pool.connect();
@@ -32,7 +31,7 @@ export async function GET(
 /* POST /api/users/[id]/flags   body: { flag: string } */
 export async function POST(
   req: Request,
-  { params }: Ctx,            // ← то же здесь
+  { params }: { params: Params }, // inline context type
 ) {
   try {
     const { flag } = (await req.json()) as { flag?: string };


### PR DESCRIPTION
## Summary
- fix Next.js route context type to avoid type errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684458dd29f88323934d6bfcf8350a5f