### PR TITLE
Fix login route syntax and update build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ pnpm dev
 bun dev
 ```
 
+Set the `DATABASE_URL` environment variable to the connection string of your
+remote PostgreSQL instance before building or starting the app. For example:
+
+```bash
+export DATABASE_URL="postgresql://user:password@remote-host:5432/dbname"
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "prisma": "prisma generate",

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -74,7 +74,6 @@ export async function POST(req: NextRequest) {
         .sign(JWT_SECRET);
 
       return NextResponse.json({ token }, { status: 200 });
-    }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 400 });


### PR DESCRIPTION
## Summary
- fix missing brace in login route
- run `prisma generate` before building
- document using DATABASE_URL for remote Postgres

## Testing
- `npx tsc --noEmit src/app/api/auth/login/route.ts` *(fails: cannot find module types)*
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447662b6388323a3150184814ed0d5