### PR TITLE
Refactor API to use Prisma ORM

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,3 +41,15 @@ model Wallet {
   @@index([user_id])
   @@map("wallets")
 }
+
+model UserFlag {
+  user_id String  @db.Uuid
+  flag    String  @db.VarChar(32)
+  set_by  String? @db.Uuid
+  set_at  DateTime @default(now()) @db.Timestamptz
+
+  user SiteUser @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@id([user_id, flag])
+  @@map("user_flags")
+}

--- a/src/app/api/users/[id]/flags/route.ts
+++ b/src/app/api/users/[id]/flags/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import pool from '@/lib/db';
+import prisma from '@/lib/prisma';
 
 export const runtime = 'nodejs';
 
@@ -11,17 +11,12 @@ export async function GET(
   { params }: { params: Params }, // inline context type
 ) {
   try {
-    const client = await pool.connect();
-    try {
-      const res = await client.query(
-        'SELECT flag FROM user_flags WHERE user_id = $1',
-        [params.id],
-      );
-      const flags = res.rows.map((r) => r.flag as string);
-      return NextResponse.json({ flags });
-    } finally {
-      client.release();
-    }
+    const res = await prisma.userFlag.findMany({
+      where: { user_id: params.id },
+      select: { flag: true },
+    });
+    const flags = res.map((r) => r.flag);
+    return NextResponse.json({ flags });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
     return NextResponse.json({ error: message }, { status: 400 });
@@ -39,18 +34,13 @@ export async function POST(
       return NextResponse.json({ error: 'flag required' }, { status: 400 });
     }
 
-    const client = await pool.connect();
-    try {
-      await client.query(
-        `INSERT INTO user_flags (user_id, flag)
-         VALUES ($1, $2)
-         ON CONFLICT DO NOTHING`,
-        [params.id, flag],
-      );
-      return NextResponse.json({ ok: true }, { status: 201 });
-    } finally {
-      client.release();
-    }
+    await prisma.userFlag.upsert({
+      where: { user_id_flag: { user_id: params.id, flag } },
+      create: { user_id: params.id, flag },
+      update: {},
+    });
+
+    return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
     return NextResponse.json({ error: message }, { status: 400 });

--- a/src/app/api/users/[id]/wallets/[wallet]/primary/route.ts
+++ b/src/app/api/users/[id]/wallets/[wallet]/primary/route.ts
@@ -1,20 +1,25 @@
 import { NextResponse } from 'next/server';
-import pool from '@/lib/db';
+import prisma from '@/lib/prisma';
 
 export async function POST(req: Request, { params }: { params: { id: string; wallet: string } }) {
-  const client = await pool.connect();
   try {
-    await client.query('BEGIN');
-    await client.query('UPDATE wallets SET is_primary=false WHERE user_id=$1', [params.id]);
-    await client.query('UPDATE wallets SET is_primary=true WHERE caip10_id=$1 AND user_id=$2', [params.wallet, params.id]);
-    await client.query('UPDATE site_users SET primary_wallet=$1 WHERE id=$2', [params.wallet, params.id]);
-    await client.query('COMMIT');
+    await prisma.$transaction([
+      prisma.wallet.updateMany({
+        where: { user_id: params.id },
+        data: { is_primary: false },
+      }),
+      prisma.wallet.update({
+        where: { caip10_id: params.wallet },
+        data: { is_primary: true },
+      }),
+      prisma.siteUser.update({
+        where: { id: params.id },
+        data: { primary_wallet: params.wallet },
+      }),
+    ]);
   } catch (err) {
-    await client.query('ROLLBACK');
     const msg = err instanceof Error ? err.message : 'unable to set primary';
     return NextResponse.json({ error: msg }, { status: 400 });
-  } finally {
-    client.release();
   }
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- add `UserFlag` model to Prisma schema
- replace raw SQL queries with Prisma ORM
- update user profile page to use Prisma

## Testing
- `npm run prisma` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447f1171988323b0fdfe8fbf47b465