### PR TITLE
Use Prisma for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ pnpm dev
 bun dev
 ```
 
+### Database Setup
+
+Create a PostgreSQL database and set `DATABASE_URL` to the connection string. You can copy `.env.example` to `.env` and fill in your credentials.
+
+Run the initial migration with Prisma:
+
+```bash
+npm run db:migrate
+```
+This Node-based script works cross-platform, including on Windows.
+
+If you use Prisma, generate migrations with:
+
+```bash
+npx prisma migrate dev --name init
+```
+For an existing database without migrations, you can use
+`npx prisma db push` or follow Prisma's [baseline guide](https://pris.ly/d/migrate-baseline).
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -21,7 +21,7 @@ CREATE TABLE site_users (
     display_name    varchar(64) UNIQUE NOT NULL,
     avatar_url      text,
     bio             text,
-    primary_wallet  varchar(128) REFERENCES wallets(caip10_id) ON DELETE SET NULL,
+    primary_wallet  varchar(128),
     role            user_role_t NOT NULL DEFAULT 'user',
     is_banned       boolean     NOT NULL DEFAULT false,
     created_at      timestamptz NOT NULL DEFAULT now(),
@@ -40,6 +40,11 @@ CREATE TABLE wallets (
 CREATE INDEX wallets_user_idx       ON wallets(user_id);
 -- Only one primary wallet per user
 CREATE UNIQUE INDEX wallets_primary_uq ON wallets(user_id) WHERE is_primary;
+
+-- Add FK from site_users.primary_wallet to wallets now that both tables exist
+ALTER TABLE site_users
+  ADD CONSTRAINT site_users_primary_wallet_fkey
+  FOREIGN KEY (primary_wallet) REFERENCES wallets(caip10_id) ON DELETE SET NULL;
 
 -- 3. Posts ---------------------------------------------------
 CREATE TABLE posts (

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "prisma": "prisma generate",
     "cms": "npm --prefix cms start",
-    "db:migrate": "psql -f migrations/001_init.sql \"$DATABASE_URL\"",
+    "db:migrate": "node ./scripts/db-migrate.js",
     "start:all": "npm run db:migrate && concurrently \"npm run cms\" \"next start\""
   },
   "dependencies": {

--- a/scripts/db-migrate.js
+++ b/scripts/db-migrate.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const { existsSync, readdirSync } = require('fs');
+const path = require('path');
+
+const dbUrl = process.env.DATABASE_URL;
+if (!dbUrl) {
+  console.error('DATABASE_URL not set');
+  process.exit(1);
+}
+
+const migrationsDir = path.join(__dirname, '..', 'prisma', 'migrations');
+if (!existsSync(migrationsDir) || readdirSync(migrationsDir).length === 0) {
+  console.error('No Prisma migrations found. Run "npx prisma migrate dev" to create one or use "npx prisma db push" to sync the schema.');
+  process.exit(1);
+}
+
+const result = spawnSync('npx', ['prisma', 'migrate', 'deploy'], { stdio: 'inherit' });
+if (result.error) {
+  console.error(result.error.message);
+}
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- remove psql-based migration script
- rename Prisma migration script to `db-migrate.js`
- update package.json and README to use Prisma for migrations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454ca986e883239561b3d938b95b32