### PR TITLE
Fix lint errors in user flags API

### DIFF
--- a/src/app/api/users/[id]/flags/route.ts
+++ b/src/app/api/users/[id]/flags/route.ts
@@ -11,7 +11,7 @@ export async function GET(
   { params }: { params: Params }, // inline context type
 ) {
   try {
-    const res = await (prisma as any).userFlag.findMany({
+    const res = await prisma.userFlag.findMany({
       where: { user_id: params.id },
       select: { flag: true },
     });
@@ -34,7 +34,7 @@ export async function POST(
       return NextResponse.json({ error: 'flag required' }, { status: 400 });
     }
 
-    await (prisma as any).userFlag.upsert({
+    await prisma.userFlag.upsert({
       where: { user_id_flag: { user_id: params.id, flag } },
       create: { user_id: params.id, flag },
       update: {},


### PR DESCRIPTION
## Summary
- remove `any` castings from the user flags route

## Testing
- `npm install --silent` *(fails: command hung or no output)*

------
https://chatgpt.com/codex/tasks/task_e_6845ea825d14832391f221e91162ca91